### PR TITLE
⚙️ [Maintenance]: Align workflows across action repositories

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -28,7 +28,7 @@ jobs:
   Release:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Code
+      - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for releases, focusing on improved clarity, expanded release triggers, and dependency updates.

Workflow improvements:

* The release workflow now also triggers on changes to any files under the `src/` directory, in addition to `action.yml`.
* Permission comments have been added to clarify why `contents: write` and `pull-requests: write` are needed.
* The step name for checking out the repository has been changed from "Checkout Code" to "Checkout repo" for clarity.

Dependency update:

* The `PSModule/Release-GHRepository` GitHub Action has been updated from version `v2.0.1` to `v2.0.2`.