### PR TITLE
allow auth to be disabled

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,12 @@ inputs:
       Similar to the `-Prerelease` switch on `Install-PSResource`.
     required: false
     default: 'false'
+  NoAuth:
+    description: |
+      If 'true', do not send an Authorization header with GitHub API requests.
+      Useful for avoiding rate limit issues when a token is not provided or desired.
+    required: false
+    default: 'false'
 
 runs:
   using: composite
@@ -34,6 +40,7 @@ runs:
       env:
         REQUESTED_VERSION: ${{ inputs.Version }}
         PRERELEASE: ${{ inputs.Prerelease }}
+        NO_AUTH: ${{ inputs.NoAuth }}
         GITHUB_TOKEN: ${{ github.token }}
       run:
         | # zizmor: ignore[github-env] GITHUB_PATH writes use hardcoded install dirs, not user input
@@ -42,6 +49,12 @@ runs:
         echo "Requested version: [$REQUESTED_VERSION]"
         echo "Prerelease: [$PRERELEASE]"
 
+        # Prepare curl arguments for GitHub API
+        CURL_AUTH=(-H "Authorization: Bearer $GITHUB_TOKEN")
+        if [[ "$NO_AUTH" == "true" ]]; then
+          CURL_AUTH=()
+        fi
+
         # Only resolve to latest version if explicitly set to 'latest' (case-insensitive)
         case "${REQUESTED_VERSION:-}" in
             [Ll][Aa][Tt][Ee][Ss][Tt])
@@ -49,7 +62,7 @@ runs:
                     REQUESTED_VERSION=$(
                       curl -s -f \
                         -H "Accept: application/vnd.github+json" \
-                        -H "Authorization: Bearer $GITHUB_TOKEN" \
+                        "${CURL_AUTH[@]}" \
                         -H "X-GitHub-Api-Version: 2022-11-28" \
                         'https://api.github.com/repos/PowerShell/PowerShell/releases?per_page=100' |
                         jq -r '[.[] | select(.prerelease == true)] | (.[0].tag_name // empty)' | sed 's/^v//'
@@ -63,7 +76,7 @@ runs:
                     REQUESTED_VERSION=$(
                       curl -s -f \
                         -H "Accept: application/vnd.github+json" \
-                        -H "Authorization: Bearer $GITHUB_TOKEN" \
+                        "${CURL_AUTH[@]}" \
                         -H "X-GitHub-Api-Version: 2022-11-28" \
                         https://api.github.com/repos/PowerShell/PowerShell/releases/latest |
                         jq -r '.tag_name' | sed 's/^v//'
@@ -101,7 +114,7 @@ runs:
         RELEASE_JSON=$(
           curl -s -f \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            "${CURL_AUTH[@]}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "https://api.github.com/repos/PowerShell/PowerShell/releases/tags/v${REQUESTED_VERSION}"
         )
@@ -222,6 +235,7 @@ runs:
       env:
         REQUESTED_VERSION: ${{ inputs.Version }}
         PRERELEASE: ${{ inputs.Prerelease }}
+        NO_AUTH: ${{ inputs.NoAuth }}
         GITHUB_TOKEN: ${{ github.token }}
       run:
         | # zizmor: ignore[github-env] GITHUB_PATH writes use hardcoded install dirs, not user input
@@ -230,6 +244,12 @@ runs:
         echo "Requested version: [$REQUESTED_VERSION]"
         echo "Prerelease: [$PRERELEASE]"
 
+        # Prepare curl arguments for GitHub API
+        CURL_AUTH=(-H "Authorization: Bearer $GITHUB_TOKEN")
+        if [[ "$NO_AUTH" == "true" ]]; then
+          CURL_AUTH=()
+        fi
+
         # Only resolve to latest version if explicitly set to 'latest' (case-insensitive)
         case "${REQUESTED_VERSION:-}" in
             [Ll][Aa][Tt][Ee][Ss][Tt])
@@ -237,7 +257,7 @@ runs:
                     REQUESTED_VERSION=$(
                       curl -s -f \
                         -H "Accept: application/vnd.github+json" \
-                        -H "Authorization: Bearer $GITHUB_TOKEN" \
+                        "${CURL_AUTH[@]}" \
                         -H "X-GitHub-Api-Version: 2022-11-28" \
                         'https://api.github.com/repos/PowerShell/PowerShell/releases?per_page=100' |
                         jq -r '[.[] | select(.prerelease == true)] | (.[0].tag_name // empty)' | sed 's/^v//'
@@ -251,7 +271,7 @@ runs:
                     REQUESTED_VERSION=$(
                       curl -s -f \
                         -H "Accept: application/vnd.github+json" \
-                        -H "Authorization: Bearer $GITHUB_TOKEN" \
+                        "${CURL_AUTH[@]}" \
                         -H "X-GitHub-Api-Version: 2022-11-28" \
                         https://api.github.com/repos/PowerShell/PowerShell/releases/latest |
                         jq -r '.tag_name' | sed 's/^v//'
@@ -321,6 +341,7 @@ runs:
       env:
         REQUESTED_VERSION: ${{ inputs.Version }}
         PRERELEASE: ${{ inputs.Prerelease }}
+        NO_AUTH: ${{ inputs.NoAuth }}
         GITHUB_TOKEN: ${{ github.token }}
       run:
         | # zizmor: ignore[github-env] GITHUB_PATH writes use hardcoded install dirs, not user input
@@ -333,9 +354,12 @@ runs:
         if ($req -and $req.Trim().ToLower() -eq 'latest') {
             $headers = @{
                 'Accept'               = 'application/vnd.github+json'
-                'Authorization'        = "Bearer $($env:GITHUB_TOKEN)"
                 'X-GitHub-Api-Version' = '2022-11-28'
             }
+            if ($env:NO_AUTH -ne 'true') {
+                $headers['Authorization'] = "Bearer $($env:GITHUB_TOKEN)"
+            }
+
             if ($env:PRERELEASE -eq 'true') {
                 $releases = Invoke-RestMethod -Uri 'https://api.github.com/repos/PowerShell/PowerShell/releases?per_page=100' -Headers $headers
                 $latestRelease = $releases | Where-Object { $_.prerelease -eq $true } | Select-Object -First 1


### PR DESCRIPTION
## Description

sending a bad auth token to github causes a 401.  If you're using gitea, then the token is never valid, so allow it to be disabled

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [X] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
